### PR TITLE
Removing the need to add the extension in imports

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -54,6 +54,9 @@ module.exports = (env, argv) => {
         devServer: {
             compress: isProduction,
             port: 3000
+        },
+        resolve: {
+            extensions: [".webpack.js", ".web.js", ".js", ".json", ".jsx"]
         }
     }
 };


### PR DESCRIPTION
I did remove the need to explicit define the extension when importing react `jsx` files.
No more 
`import xx from './xx.jsx'`